### PR TITLE
Hacky SNA writer + checksum calculation.

### DIFF
--- a/Assets/Scripts/OpenSpace/FileFormat/SNA.cs
+++ b/Assets/Scripts/OpenSpace/FileFormat/SNA.cs
@@ -58,6 +58,34 @@ namespace OpenSpace.FileFormat {
             ReadSNA();
         }
 
+        public void WriteSNA()
+        {
+            if (Settings.s.game == Settings.Game.TT)
+            {
+                throw new NotImplementedException();
+                //byte headerLength = reader.ReadByte();
+                //reader.ReadBytes(headerLength);
+            }
+            foreach (SNAMemoryBlock block in blocks)
+            {
+                writer.Write(block.module);
+                writer.Write(block.id);
+                if (Settings.s.engineVersion > Settings.EngineVersion.Montreal) writer.Write(block.unk1);
+                writer.Write(block.baseInMemory);
+
+                if (block.baseInMemory != -1)
+                {
+                    writer.Write(block.unk2);
+                    writer.Write(block.unk3);
+                    writer.Write(block.maxPosMinus9);
+                    writer.Write(block.size);
+                    if (Settings.s.game == Settings.Game.TT) writer.Write(block.unk1);
+
+                    WriteSNABlock(block);
+                }
+            }
+        }
+
         void ReadSNA() {
             MapLoader l = MapLoader.Loader;
             uint szCounter = 0;
@@ -213,6 +241,61 @@ namespace OpenSpace.FileFormat {
                 } else {
                     reader.ReadBytes((int)block.size);
                 }
+            }
+        }
+        long CalculateChecksum(SNAMemoryBlock block)
+        {
+            long v4 = 1;
+            long v5 = 0;
+            long v39 = 0;
+            
+            if (data == null) {
+                return 1;
+            }
+
+            uint offset = block.dataPosition;
+            for (uint i = block.size; i != 0; v5 %= 0xFFF1u)
+            {
+                uint v8 = i;
+                if (i >= 5552)
+                    v8 = 5552;
+                for (i -= v8; v8 >= 16; v5 = v4 + v39)
+                {
+                    v8 -= 16;
+                    v39 = data[offset + 14] + 2 * data[offset + 13] + 3 * data[offset + 12] + 4 * data[offset + 11] + 5 * data[offset + 10] + 6 * data[offset + 9] + 7 * data[offset + 8] + 8 * data[offset + 7] + 9 * data[offset + 6] + 10 * data[offset + 5] + 11 * data[offset + 4] + 12 * data[offset + 3] + 13 * data[offset + 2] + 14 * data[offset + 1] + 15 * data[offset + 0] + 15 * v4 + v5;
+                    v4 = data[offset + 15] + data[offset + 14] + data[offset + 13] + data[offset + 12] + data[offset + 11] + data[offset + 10] + data[offset + 9] + data[offset + 8] + data[offset + 7] + data[offset + 6] + data[offset + 5] + data[offset + 4] + data[offset + 3] + data[offset + 2] + data[offset + 1] + data[offset + 0] + v4;
+
+                    offset += 16;
+                }
+                if (v8 != 0)
+                {
+                  do
+                  {
+                    v4 += data[offset++];
+                    v5 += v4;
+                    --v8;
+                  }
+                  while (v8 > 0);
+                }
+                v4 %= 0xFFF1u;
+            }
+            return v4 | (v5 << 16);
+        }
+
+        void WriteSNABlock(SNAMemoryBlock block)
+        {
+            if (block.size > 0)
+            {
+                uint checksum = (uint)CalculateChecksum(block);
+                writer.Write(0); // no compression
+                // compressed size & checksum
+                writer.Write(block.size);
+                writer.Write(checksum);
+                // decompressed size & checksum
+                writer.Write(block.size);
+                writer.Write(checksum);
+
+                writer.BaseStream.Write(data, (int)block.dataPosition, (int)block.size);
             }
         }
 
@@ -519,7 +602,11 @@ namespace OpenSpace.FileFormat {
         }
 
         public override void CreateWriter() {
-            return; // No writing support for SNA files yet
+            if (path != null)
+            {
+                FileStream stream = new FileStream(path, FileMode.Open);
+                writer = new Writer(stream, Settings.s.IsLittleEndian);
+            }
         }
 
         public override void WritePointer(Pointer pointer) {

--- a/Assets/Scripts/OpenSpace/Loader/MapLoader.cs
+++ b/Assets/Scripts/OpenSpace/Loader/MapLoader.cs
@@ -234,7 +234,16 @@ namespace OpenSpace {
         public void Save() {
             try {
                 for (int i = 0; i < files_array.Length; i++) {
-                    if (files_array[i] != null) files_array[i].CreateWriter();
+					if (files_array[i] != null)
+					{
+						files_array[i].CreateWriter();
+						if (files_array[i] is SNA)
+						{
+							(files_array[i] as SNA).WriteSNA();
+							files_array[i].Dispose();
+							files_array[i] = null;
+						}
+					}
                 }
                 // Save changes
                 SaveModdables();


### PR DESCRIPTION
Hey, how are you? :)

I recently got hit by nostalgia which got me to watch videos about Hype: The Time Quest, where I found out about your project. I wanted to play around a bit and make some minor change, for a proof of concept, but it seemed like save buttons are not working, so I started looking into the code and found out the SNA writer indeed says it is not implemented.

I don't really understand the whole structure - I don't have much experience in C# or Unity, so I just hacked my way into saving to check if I could implement it, just by mirroring the read function.

The game yelled at me for writing bad checksum though, so I had to reverse engineer this part of Hype's engine, which luckily went pretty smoothly.

The code now successfully reads the compressed Hype levels and overwrites them with uncompressed SNAs that can be ran by the game (they even load noticeably faster ;))... but sadly no map changes are there... I'm guessing the whole SNAMemoryBlocks are used just as a read-only, intermediate structure, and you don't ever write changes from Unity there?

I hope you can make some use of this PR and I'll be waiting for any progress on the editor - it's good to find out I'm not the only one doing such things. Hit me up if you need anything.

Good luck! 