### PR TITLE
PK: Out of Shadows doesn't have an Xbox version

### DIFF
--- a/Wiki/List Of OpenSpace Games.md
+++ b/Wiki/List Of OpenSpace Games.md
@@ -151,7 +151,7 @@
     <td class="tg-yw4l"></td>
     <td class="tg-yw4l">✔️</td>
     <td class="tg-yw4l">❌</td>
-    <td class="tg-yw4l">❌</td>
+    <td class="tg-yw4l"></td>
     <td class="tg-yw4l"></td>
     <td class="tg-yw4l"></td>
     <td class="tg-yw4l"></td>


### PR DESCRIPTION
Just removes the X from PK: Out of Shadows since there is no Xbox version for that game.